### PR TITLE
spotupnp: fix teardown deadlock when removing a renderer

### DIFF
--- a/spotupnp/src/mr_util.c
+++ b/spotupnp/src/mr_util.c
@@ -130,10 +130,10 @@ void FlushMRDevices(void) {
 			// spotupnp.c: do not hold p->Mutex across spotDeletePlayer(), because
 			// the player task's teardown needs that mutex (via shadowRequest) to
 			// make progress, and ~CSpotPlayer() blocks until the task exits.
-			struct spotPlayer *player = p->SpotPlayer;
+			struct spotPlayer *Player = p->SpotPlayer;
 			p->SpotPlayer = NULL;
 			pthread_mutex_unlock(&p->Mutex);
-			spotDeletePlayer(player);
+			spotDeletePlayer(Player);
 			pthread_mutex_lock(&p->Mutex);
 			// device's mutex returns unlocked
 			DelMRDevice(p);

--- a/spotupnp/src/mr_util.c
+++ b/spotupnp/src/mr_util.c
@@ -130,10 +130,10 @@ void FlushMRDevices(void) {
 			// spotupnp.c: do not hold p->Mutex across spotDeletePlayer(), because
 			// the player task's teardown needs that mutex (via shadowRequest) to
 			// make progress, and ~CSpotPlayer() blocks until the task exits.
-			struct spotPlayer *dying = p->SpotPlayer;
+			struct spotPlayer *player = p->SpotPlayer;
 			p->SpotPlayer = NULL;
 			pthread_mutex_unlock(&p->Mutex);
-			spotDeletePlayer(dying);
+			spotDeletePlayer(player);
 			pthread_mutex_lock(&p->Mutex);
 			// device's mutex returns unlocked
 			DelMRDevice(p);

--- a/spotupnp/src/mr_util.c
+++ b/spotupnp/src/mr_util.c
@@ -126,8 +126,16 @@ void FlushMRDevices(void) {
 		struct sMR *p = &glMRDevices[i];
 		pthread_mutex_lock(&p->Mutex);
 		if (p->Running) {
+			// Same lock-ordering rule as the per-renderer removal paths in
+			// spotupnp.c: do not hold p->Mutex across spotDeletePlayer(), because
+			// the player task's teardown needs that mutex (via shadowRequest) to
+			// make progress, and ~CSpotPlayer() blocks until the task exits.
+			struct spotPlayer *dying = p->SpotPlayer;
+			p->SpotPlayer = NULL;
+			pthread_mutex_unlock(&p->Mutex);
+			spotDeletePlayer(dying);
+			pthread_mutex_lock(&p->Mutex);
 			// device's mutex returns unlocked
-			spotDeletePlayer(p->SpotPlayer);
 			DelMRDevice(p);
 		} else pthread_mutex_unlock(&p->Mutex);
 	}

--- a/spotupnp/src/spotify.cpp
+++ b/spotupnp/src/spotify.cpp
@@ -522,6 +522,10 @@ void CSpotPlayer::disconnect(bool abort) {
 }
 
 bool getMetaForUrl(CSpotPlayer* self, const std::string url, metadata_t* metadata) {
+    // Device->Mutex is released around spotDeletePlayer(), during which Device->SpotPlayer
+    // is NULL. Callers such as spotupnp.c's ActionHandler do not null-check, so guard here
+    // to keep NULL a valid sentinel, matching the contract that notify() already upholds.
+    if (!self) return false;
     for (auto it = self->streamers.begin(); it != self->streamers.end(); ++it) {
         if ((*it)->getStreamUrl() == url) {
             (*it)->getMetadata(metadata);

--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -802,8 +802,6 @@ static void *UpdateThread(void *args) {
 						// if device does not answer, try to download its DescDoc
 						IXML_Document* DescDoc = NULL;
 						if (UpnpDownloadXmlDoc(Device->DescDocURL, &DescDoc) != UPNP_E_SUCCESS) {
-							struct spotPlayer *dying;
-
 							pthread_mutex_lock(&Device->Mutex);
 							LOG_INFO("[%p]: removing unresponsive player (%s) with error count %d and timeout %d", Device,
 								      Device->Config.Name, Device->ErrorCount, now - Device->LastSeen);
@@ -811,10 +809,10 @@ static void *UpdateThread(void *args) {
 							// spotDeletePlayer blocks in ~CSpotPlayer until the player task exits, and that
 							// task's teardown calls shadowRequest which takes Device->Mutex. Holding the mutex
 							// here would deadlock and leave the renderer gone from Spotify until restart.
-							dying = Device->SpotPlayer;
+							struct spotPlayer *Player = Device->SpotPlayer;
 							Device->SpotPlayer = NULL;
 							pthread_mutex_unlock(&Device->Mutex);
-							spotDeletePlayer(dying);
+							spotDeletePlayer(Player);
 							pthread_mutex_lock(&Device->Mutex);
 
 							// device's mutex returns unlocked

--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -901,17 +901,15 @@ static void *UpdateThread(void *args) {
 																  Device->Config.CacheMode, (struct shadowPlayer*) Device, &Device->Mutex);
 							pthread_mutex_unlock(&Device->Mutex);
 						} else if (Master && (!Device->Master || Device->Master == Device)) {
-							struct spotPlayer *dying;
-
 							pthread_mutex_lock(&Device->Mutex);
 							LOG_INFO("[%p]: Sonos %s is now slave", Device, Device->Config.Name);
 							Device->Master = Master;
 
 							// Same lock-ordering rule as above.
-							dying = Device->SpotPlayer;
+							struct spotPlayer *Player = Device->SpotPlayer;
 							Device->SpotPlayer = NULL;
 							pthread_mutex_unlock(&Device->Mutex);
-							spotDeletePlayer(dying);
+							spotDeletePlayer(Player);
 						}
 
 						NFREE(friendlyName);

--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -829,8 +829,6 @@ static void *UpdateThread(void *args) {
 
 			// device removal request
 			} else if (Update->Type == BYE_BYE) {
-				struct spotPlayer *dying;
-
 				Device = UDN2Device(Update->Data);
 
 				// Multiple bye-bye might be sent
@@ -840,10 +838,10 @@ static void *UpdateThread(void *args) {
 
 				// Same lock-ordering rule as the presence-timeout path: drop Device->Mutex
 				// before spotDeletePlayer so the player task can take it and exit cleanly.
-				dying = Device->SpotPlayer;
+				struct spotPlayer *Player = Device->SpotPlayer;
 				Device->SpotPlayer = NULL;
 				pthread_mutex_unlock(&Device->Mutex);
-				spotDeletePlayer(dying);
+				spotDeletePlayer(Player);
 				pthread_mutex_lock(&Device->Mutex);
 
 				// device's mutex returns unlocked

--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -802,10 +802,21 @@ static void *UpdateThread(void *args) {
 						// if device does not answer, try to download its DescDoc
 						IXML_Document* DescDoc = NULL;
 						if (UpnpDownloadXmlDoc(Device->DescDocURL, &DescDoc) != UPNP_E_SUCCESS) {
+							struct spotPlayer *dying;
+
 							pthread_mutex_lock(&Device->Mutex);
 							LOG_INFO("[%p]: removing unresponsive player (%s) with error count %d and timeout %d", Device,
 								      Device->Config.Name, Device->ErrorCount, now - Device->LastSeen);
-							spotDeletePlayer(Device->SpotPlayer);
+
+							// spotDeletePlayer blocks in ~CSpotPlayer until the player task exits, and that
+							// task's teardown calls shadowRequest which takes Device->Mutex. Holding the mutex
+							// here would deadlock and leave the renderer gone from Spotify until restart.
+							dying = Device->SpotPlayer;
+							Device->SpotPlayer = NULL;
+							pthread_mutex_unlock(&Device->Mutex);
+							spotDeletePlayer(dying);
+							pthread_mutex_lock(&Device->Mutex);
+
 							// device's mutex returns unlocked
 							DelMRDevice(Device);
 						} else {
@@ -820,6 +831,7 @@ static void *UpdateThread(void *args) {
 
 			// device removal request
 			} else if (Update->Type == BYE_BYE) {
+				struct spotPlayer *dying;
 
 				Device = UDN2Device(Update->Data);
 
@@ -827,7 +839,15 @@ static void *UpdateThread(void *args) {
 				if (!CheckAndLock(Device)) continue;
 
 				LOG_INFO("[%p]: renderer bye-bye: %s", Device, Device->Config.Name);
-				spotDeletePlayer(Device->SpotPlayer);
+
+				// Same lock-ordering rule as the presence-timeout path: drop Device->Mutex
+				// before spotDeletePlayer so the player task can take it and exit cleanly.
+				dying = Device->SpotPlayer;
+				Device->SpotPlayer = NULL;
+				pthread_mutex_unlock(&Device->Mutex);
+				spotDeletePlayer(dying);
+				pthread_mutex_lock(&Device->Mutex);
+
 				// device's mutex returns unlocked
 				DelMRDevice(Device);
 
@@ -885,12 +905,17 @@ static void *UpdateThread(void *args) {
 																  Device->Config.CacheMode, (struct shadowPlayer*) Device, &Device->Mutex);
 							pthread_mutex_unlock(&Device->Mutex);
 						} else if (Master && (!Device->Master || Device->Master == Device)) {
+							struct spotPlayer *dying;
+
 							pthread_mutex_lock(&Device->Mutex);
 							LOG_INFO("[%p]: Sonos %s is now slave", Device, Device->Config.Name);
 							Device->Master = Master;
-							spotDeletePlayer(Device->SpotPlayer);
+
+							// Same lock-ordering rule as above.
+							dying = Device->SpotPlayer;
 							Device->SpotPlayer = NULL;
 							pthread_mutex_unlock(&Device->Mutex);
+							spotDeletePlayer(dying);
 						}
 
 						NFREE(friendlyName);


### PR DESCRIPTION
Hit this on my setup: one of my UPnP renderers vanished from Spotify Connect and spotupnp sat at 100% CPU until I restarted it. Traced it to a lock ordering bug between `UpdateThread` and the `CSpotPlayer` task.

`UpdateThread` holds `Device->Mutex` while it calls `spotDeletePlayer()`. The destructor waits on `runningMutex` for `runTask()` to exit, but `runTask()`'s teardown goes through `shadowRequest()`, which needs `Device->Mutex`. Both threads wait on each other forever. Since `~CSpotPlayer()` has already unregistered mDNS at that point, the renderer stays gone from Spotify until restart. The pegged core is cspot's track feed loop retrying `writePCM()`, which returns 0 for everything once `isRunning` is false.

In the logs this shows up as `player <X> deletion pending` with no `disconnecting player <X>` ever following.

The fix is to not hold `Device->Mutex` across `spotDeletePlayer()`. Applied at all four call sites (presence timeout, BYE_BYE, Sonos master-to-slave transition, `FlushMRDevices()`):

```c
dying = Device->SpotPlayer;
Device->SpotPlayer = NULL;
pthread_mutex_unlock(&Device->Mutex);
spotDeletePlayer(dying);
pthread_mutex_lock(&Device->Mutex);   // only where DelMRDevice follows
```

`Device->SpotPlayer` is nulled before unlocking so nothing can reach a player that is being destroyed. Callers going through `notify()` already handle NULL; `getMetaForUrl()` didn't, so it gets a null check too.

After the fix the renderer re-registers on the next UPnP search cycle (about 30 s), no restart needed.
