### PR TITLE
spotupnp: identify the started track when notifying cspot

### DIFF
--- a/spotupnp/src/spotify.cpp
+++ b/spotupnp/src/spotify.cpp
@@ -483,7 +483,9 @@ void notify(CSpotPlayer *self, enum shadowEvent event, va_list args) {
 
         // finally, get ready for time position and inform spotify that we are playing
         self->lastPosition = 0;
-        if (self->notify) self->spirc->notifyAudioReachedPlayback();
+        // pass the started stream's track so a stale start (from a stream that predates
+        // a queue rebuild) cannot advance the queue and desync playback for good
+        if (self->notify) self->spirc->notifyAudioReachedPlayback(self->player->trackUnique);
         else self->notify = true;
 
         // avoid weird cases where position is either random or last seek (will be corrected by SHADOW_TIME)


### PR DESCRIPTION

Companion of philippe44/cspot#2, see there for the full analysis.

Short version: a "started by URL" notification from a streamer created before cspot's queue was rebuilt (it races the reload that follows a `Load` frame, e.g. a track change from a second Connect controller) advances the queue one entry early and it never resyncs: every song afterwards is restarted at its data-feed EOF, cutting off the 60-90 s still buffered in the renderer, until spotupnp is restarted.

Passes the started streamer's `trackUnique` to `notifyAudioReachedPlayback()` so cspot can reject stale and duplicate notifications; the flow-mode call site keeps the legacy empty-identifier behavior. Needs the cspot PR merged and the submodule bumped past it first - this does not build against the currently recorded cspot revision.

Verified against a Hama DIT2010: the desync reproduced reliably with rapid track changes from a second controller on 0.20.3; with both PRs the stale notifications are ignored and every track plays to its real end.
