### PR TITLE
spotupnp: do not mistake our own stop acknowledgment for a user stop

### DIFF
--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -363,6 +363,12 @@ void shadowRequest(struct shadowPlayer *shadow, enum spotEvent event, ...) {
 		if (Device->State != PLAYING || Device->ExpectStop) AVTPlay(Device);
 		// should we set volume?
 		Device->SpotState = SPOT_PLAY;
+		/* ExpectStop must survive until ActionHandler processes a transport
+		 * state with playback re-established: a renderer that is slow to leave
+		 * STOPPED can still report the STOPPED caused by our own AVTStop after
+		 * it has acknowledged this play, and clearing the flag early makes that
+		 * late report look like a user-initiated stop, which disconnects the
+		 * player */
 		break;
 	}
 	case SPOT_PAUSE:
@@ -529,8 +535,11 @@ int ActionHandler(Upnp_EventType EventType, const void *Event, void *Cookie) {
 				_ProcessQueue(p);
 
 				if (Resp && !strcasecmp(Resp, "PlayResponse")) {
-					// with and after a PlayResponse, we can't expect a STOPPED state
-					p->ExpectStop = false;
+					/* do NOT clear ExpectStop here: a renderer that is slow to leave
+					 * STOPPED (e.g. tearing down a buffered stream after a pause) can
+					 * still report the STOPPED caused by our own stop after it has
+					 * acknowledged this play; the flag is cleared once a transport
+					 * state is processed with playback re-established */
 					/* when play action has been completed, the state need to be re-acquired because we
 					 * might have missed a state in-between. For example, while seeking there is a very
 					 * stop/play so the STOPPED state will be missed and the PLAYING event will be as
@@ -573,12 +582,11 @@ int ActionHandler(Upnp_EventType EventType, const void *Event, void *Cookie) {
 							// some players (Sonos again...) report a STOPPED state when pause *only* with mp3
 							spotNotify(p->SpotPlayer, SHADOW_STOP);
 						}
-						break;
 					}
 
 					// move to STOPPED state anyway as next detection will re-sync us
 					p->State = STOPPED;
-					p->ExpectStop = false;	
+					p->ExpectStop = false;
 				} else if (!strcmp(r, "PLAYING") && (p->State != PLAYING)) {
 					p->State = PLAYING;
 					LOG_INFO("[%p]: uPNP playing", p);
@@ -588,6 +596,15 @@ int ActionHandler(Upnp_EventType EventType, const void *Event, void *Cookie) {
 					LOG_INFO("[%p]: uPNP pause", p);
 					if (p->SpotState == SPOT_PLAY) spotNotify(p->SpotPlayer, SHADOW_PAUSE);
 				}
+
+				/* the expected-stop suppression ends with the first transport state
+				 * processed once we are playing again (SpotState reflects the play
+				 * that follows our own stop; a state observed before that can be a
+				 * leftover of the stop still being executed). A renderer whose
+				 * pipeline is slow can legitimately still report the STOPPED caused
+				 * by our own stop on that first poll (the branch above absorbs it
+				 * exactly once); anything observed after that is genuine again */
+				if (p->SpotState == SPOT_PLAY) p->ExpectStop = false;
 
 				free(r);
 			}


### PR DESCRIPTION

Hit this on my setup: changing track while paused kicked the renderer off my Spotify account - I had to re-select the device and press play. Reproduced at will with pause, wait a few seconds, change track.

## What happens

A track change (spirc `Load` frame) restarts the renderer with Stop, SetURI and Play within ~100 ms. `SPOT_STOP` arms `ExpectStop` so the STOPPED that acknowledges our own `AVTStop` is not mistaken for a user stop - but `SPOT_PLAY` clears the flag as soon as the play *command is sent*, not when the renderer has been observed past the stop. When the renderer is slow to execute (typical when it was paused), the next transport-state poll still returns STOPPED after the play:

```
12:09:15.965  AVTStop            ExpectStop = true
12:09:16.054  AVTPlay            ExpectStop = false (too early)
12:09:16.5xx  poll -> STOPPED    SpotState == SPOT_PLAY, !ExpectStop
12:09:16.594  "Disconnecting"    session freed, device gone from the account
```

ActionHandler treats the stale STOPPED as user-initiated and the "disconnect on unexpected STOP" logic releases the player. It usually goes unnoticed because the poll tends to land inside the short `SpotState == SPOT_STOP` window, or the renderer transitions fast enough that STOPPED is never polled.

## Fix

- keep `ExpectStop` armed until ActionHandler actually observes a transport state: an expected STOPPED is consumed silently, and TRANSITIONING / PLAYING / PAUSED_PLAYBACK observations disarm it
- those observations only fire on a state *change*, so a renderer that coalesces states could leave the flag armed and a later genuine stop would be swallowed; the suppression therefore only honors the flag within 5 s of the stop command (`ExpectStopTime`). Past the window a STOPPED is genuine again - worst case is one absorbed stop right after a track change, instead of either permanent failure
- `SPOT_LOAD` now frees any pending `NextStreamUrl` when it does a full `SetTrackURI` load; a suppressed expected stop skips the branch that used to free it, and a stale gapped-next URL must not survive into the new track

## Notes

With the fix, the same repro shows the late acknowledgment being absorbed (`AVTStop` .203, `AVTPlay` .284, STOPPED polled .604 - no disconnect) and playback continues; a genuine renderer stop still frees the session as designed. Independent of the stale-notification PR.
