### PR TITLE
spotupnp: verify a bye-bye before removing the renderer

### DIFF
--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -857,10 +857,31 @@ static void *UpdateThread(void *args) {
 
 			// device removal request
 			} else if (Update->Type == BYE_BYE) {
+				IXML_Document* DescDoc = NULL;
+
 				Device = UDN2Device(Update->Data);
 
 				// Multiple bye-bye might be sent
 				if (!CheckAndLock(Device)) continue;
+
+				/* some renderers (e.g. Hama DIT2010) cycle bye-bye/alive when their AV
+				 * stack restarts on a stream transition, while they keep playing and
+				 * answering requests; removing the player kills the Spotify session, so
+				 * before trusting the bye-bye check whether the device still answers its
+				 * description URL, like the presence-timeout path does. Do not hold the
+				 * device's mutex across the blocking download; only this thread removes
+				 * devices, so the slot cannot go away meanwhile */
+				pthread_mutex_unlock(&Device->Mutex);
+				bool alive = UpnpDownloadXmlDoc(Device->DescDocURL, &DescDoc) == UPNP_E_SUCCESS;
+				if (DescDoc) ixmlDocument_free(DescDoc);
+				if (!CheckAndLock(Device)) continue;
+
+				if (alive) {
+					Device->LastSeen = now;
+					LOG_INFO("[%p]: ignoring bye-bye from a live renderer (%s)", Device, Device->Config.Name);
+					pthread_mutex_unlock(&Device->Mutex);
+					continue;
+				}
 
 				LOG_INFO("[%p]: renderer bye-bye: %s", Device, Device->Config.Name);
 


### PR DESCRIPTION

Hit this on my setup several times per evening, usually right after a track change: playback stopped, the renderer disappeared from Spotify Connect for about 15 seconds, and I had to re-select it and press play.

## What happens

My renderer (Hama DIT2010) sends spurious `ssdp:byebye` announcements when its AV stack restarts around a stream transition, while it keeps playing and answering control requests. spotupnp trusts every bye-bye, so the player is deleted - which tears down the Spotify session - and the device only comes back when it re-announces:

```
19:53:36.953  renderer bye-bye: Hama DIT2010+
19:53:36.953  player <Hama DIT2010+> deletion pending
19:53:50.718  adding renderer (Hama DIT2010)     <- 14 s later, session gone
```

In one instance the renderer had even started playing the next track nine seconds before its bye-bye was processed.

## Fix

Before honoring a bye-bye, download the device description - the same probe the presence-timeout path already does before removing an unresponsive player. If the device answers, it is alive: refresh `LastSeen`, log it and keep the player. If it does not answer, remove it as before, so genuine shutdowns still clean up (and a device that answers once and then goes silent is caught by the presence timeout later anyway).

The probe runs without holding the device mutex, since it is a blocking download; only UpdateThread removes devices, so the slot cannot disappear between the unlock and the re-check.

## Notes

Running on my setup since yesterday: 48 bye-byes absorbed (`ignoring bye-bye from a live renderer`), including 5 within 1.4 s, and no session drop - where the same renderer previously forced a reconnect four times in one evening.

Independent of the other PRs, based on 0.20.4.
