### PR TITLE
spotupnp: announce the renderer's volume on connection instead of 0

### DIFF
--- a/spotupnp/src/avt_util.c
+++ b/spotupnp/src/avt_util.c
@@ -250,7 +250,7 @@ int CtrlGetGroupVolume(struct sMR *Device) {
 	struct sService *Service = &Device->Service[GRP_REND_SRV_IDX];
 	int Volume = -1;
 
-	if (*Service->ControlURL) return Volume;
+	if (!*Service->ControlURL) return Volume;
 
 	ActionNode = UpnpMakeAction("GetGroupVolume", Service->Type, 0, NULL);
 	UpnpAddToAction(&ActionNode, "GetGroupVolume", Service->Type, "InstanceID", "0");
@@ -277,7 +277,7 @@ int CtrlGetVolume(struct sMR *Device) {
 	struct sService *Service = &Device->Service[REND_SRV_IDX];
 	int Volume = -1;
 
-	if (*Service->ControlURL) return Volume;
+	if (!*Service->ControlURL) return Volume;
 
 	ActionNode = UpnpMakeAction("GetVolume", Service->Type, 0, NULL);
 	UpnpAddToAction(&ActionNode, "GetVolume", Service->Type, "InstanceID", "0");

--- a/spotupnp/src/mr_util.c
+++ b/spotupnp/src/mr_util.c
@@ -25,7 +25,7 @@ static IXML_Node*	_getAttributeNode(IXML_Node *node, char *SearchAttr);
 int 				_voidHandler(Upnp_EventType EventType, const void *_Event, void *Cookie) { return 0; }
 
 /*----------------------------------------------------------------------------*/
-int CalcGroupVolume(struct sMR *Device) {
+int CalcGroupVolume(struct sMR *Device, bool query) {
 	int i, n = 0;
 	double GroupVolume = 0;
 
@@ -34,13 +34,18 @@ int CalcGroupVolume(struct sMR *Device) {
 	for (i = 0; i < glMaxDevices; i++) {
 		struct sMR *p = glMRDevices + i;
 		if (p->Running && (p == Device || p->Master == Device)) {
-			if (p->Volume == -1) p->Volume = CtrlGetVolume(p);
+			/* asking a member costs a synchronous request per unknown volume, so
+			 * callers that must not block settle for what is already cached */
+			if (p->Volume == -1 && query) p->Volume = CtrlGetVolume(p);
+
+			// a member whose volume we can't read must not drag the average down
+			if (p->Volume < 0) continue;
 			GroupVolume += p->Volume;
 			n++;
 		}
 	}
 
-	return GroupVolume / n;
+	return n ? GroupVolume / n : -1;
 }
 
 /*----------------------------------------------------------------------------*/

--- a/spotupnp/src/mr_util.h
+++ b/spotupnp/src/mr_util.h
@@ -14,7 +14,7 @@
 void 		FlushMRDevices(void);
 void 		DelMRDevice(struct sMR *p);
 struct sMR *GetMaster(struct sMR *Device, char **Name);
-int 		CalcGroupVolume(struct sMR *Master);
+int 		CalcGroupVolume(struct sMR *Master, bool query);
 bool		CheckAndLock(struct sMR *Device);
 double		GetLocalGroupVolume(struct sMR *Member, int *count);
 

--- a/spotupnp/src/spotify.cpp
+++ b/spotupnp/src/spotify.cpp
@@ -84,7 +84,8 @@ private:
     shadowMutex playerMutex;
     bell::WrappedSemaphore clientConnected;
     std::string streamTrackUnique;
-    int volume = 0;
+    // written by the shadow's thread on local volume changes, read when a session starts
+    std::atomic<int> volume = 0;
     int32_t startOffset;
 
     uint64_t lastTimeStamp;
@@ -123,7 +124,7 @@ private:
 public:
     inline static std::string username = "", password = "";
 
-    CSpotPlayer(char *clientId, char *clientSecret, char* name, char* id, char *credentials, struct in_addr addr, AudioFormat audio, char* codec, bool flow,
+    CSpotPlayer(char *clientId, char *clientSecret, char* name, char* id, char *credentials, struct in_addr addr, AudioFormat audio, char* codec, bool flow, int volume,
         int64_t contentLength, int cacheMode, struct shadowPlayer* shadow, pthread_mutex_t* mutex);
     ~CSpotPlayer();
     void disconnect(bool abort = false);
@@ -132,10 +133,10 @@ public:
     bool friend getMetaForUrl(CSpotPlayer* self, const std::string url, metadata_t* metadata);
 };
 
-CSpotPlayer::CSpotPlayer(char *clientId, char* clientSecret, char* name, char* id, char *credentials, struct in_addr addr, AudioFormat format, char* codec, bool flow,
+CSpotPlayer::CSpotPlayer(char *clientId, char* clientSecret, char* name, char* id, char *credentials, struct in_addr addr, AudioFormat format, char* codec, bool flow, int volume,
     int64_t contentLength, int cacheMode, struct shadowPlayer* shadow, pthread_mutex_t* mutex) : bell::Task("playerInstance",
         48 * 1024, 0, 0),
-    clientConnected(1), codec(codec), id(id), addr(addr), flow(flow),
+    clientConnected(1), codec(codec), id(id), addr(addr), flow(flow), volume(volume),
     clientId(clientId), clientSecret(clientSecret), name(name), credentials(credentials), format(format), shadow(shadow), 
     playerMutex(mutex), cacheMode(cacheMode) {
     this->contentLength = (flow && contentLength == HTTP_CL_REAL) ? HTTP_CL_NONE : contentLength;
@@ -397,7 +398,7 @@ void CSpotPlayer::trackHandler(std::string_view trackUnique) {
         break;
     case cspot::SpircHandler::EventType::VOLUME:
         volume = std::get<int>(event->data);
-        shadowRequest(shadow, SPOT_VOLUME, volume);
+        shadowRequest(shadow, SPOT_VOLUME, volume.load());
         break;
     case cspot::SpircHandler::EventType::TRACK_INFO: {
         /* We can't use this directly to to set player->trackInfo because with ICY mode, the metadata
@@ -592,6 +593,11 @@ void CSpotPlayer::runTask() {
         ctx->config.clientId = clientId;
         ctx->config.clientSecret = clientSecret;
 
+        /* the very first frame sent to Spotify (Hello) carries the device's volume,
+         * taken from there, so it must be the shadow's one or the controller will
+         * display (and echo back) a null volume until playback starts */
+        ctx->config.volume = volume;
+
         // seems that mbedtls can catch error that are not fatal, so we should continue
         try {
             ctx->session->connectWithRandomAp();
@@ -664,14 +670,14 @@ void spotClose(void) {
 }
 
 struct spotPlayer* spotCreatePlayer(char *client_id, char* client_secret, char* name, char *id, char * credentials, struct in_addr addr, int oggRate, 
-                                        char *codec, bool flow, int64_t contentLength, int CacheMode, 
+                                        char *codec, bool flow, int64_t contentLength, int CacheMode, int volume,
                                         struct shadowPlayer* shadow, pthread_mutex_t *mutex) {
     AudioFormat format = AudioFormat_OGG_VORBIS_160;
 
     if (oggRate == 320) format = AudioFormat_OGG_VORBIS_320;
     else if (oggRate == 96) format = AudioFormat_OGG_VORBIS_96;
 
-    auto player = new CSpotPlayer(client_id, client_secret, name, id, credentials, addr, format, codec, flow, contentLength, CacheMode, shadow, mutex);
+    auto player = new CSpotPlayer(client_id, client_secret, name, id, credentials, addr, format, codec, flow, volume, contentLength, CacheMode, shadow, mutex);
     if (player->startTask()) return (struct spotPlayer*) player;
 
     delete player;

--- a/spotupnp/src/spotify.h
+++ b/spotupnp/src/spotify.h
@@ -36,7 +36,7 @@ struct shadowPlayer;
 void				   shadowRequest(struct shadowPlayer* shadow, enum spotEvent event, ...);
 
 struct spotPlayer* spotCreatePlayer(char *clientId, char*clientSecret, char* name, char* id, char *credentials, struct in_addr addr, int audio, char *codec, bool flow, 
-								    int64_t contentLength, int cacheMode, struct shadowPlayer* shadow, pthread_mutex_t *mutex);
+								    int64_t contentLength, int cacheMode, int volume, struct shadowPlayer* shadow, pthread_mutex_t *mutex);
 void spotDeletePlayer(struct spotPlayer *spotPlayer);
 bool spotGetMetaForUrl(struct spotPlayer* spotPlayer, const char* url, metadata_t* metadata);
 void spotOpen(uint16_t portBase, uint16_t portRange, char* username, char *password);

--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -388,7 +388,7 @@ void shadowRequest(struct shadowPlayer *shadow, enum spotEvent event, ...) {
 		int GroupVolume;
 
 		// Sonos group volume API is unreliable, need to create our own
-		GroupVolume = CalcGroupVolume(Device);
+		GroupVolume = CalcGroupVolume(Device, true);
 
 		/* Volume is kept as a double in device's context to avoid relative values going 
 		 * to 0 and being stuck there. This works because although volume is echoed from 
@@ -403,10 +403,10 @@ void shadowRequest(struct shadowPlayer *shadow, enum spotEvent event, ...) {
 		} else {
 			double Ratio = GroupVolume ? (Volume * Device->Config.MaxVolume) / GroupVolume : 0;
 			
-			// set volume for all devices
+			// set volume for all devices, leaving alone any we could not read
 			for (int i = 0; i < glMaxDevices; i++) {
 				struct sMR *p = glMRDevices + i;
-				if (!p->Running || (p != Device && p->Master != Device)) continue;
+				if (!p->Running || (p != Device && p->Master != Device) || p->Volume < 0) continue;
 
 				// for standalone master, GroupVolume & Volume are identical
 				if (GroupVolume) p->Volume = min(p->Volume * Ratio, p->Config.MaxVolume);
@@ -479,7 +479,7 @@ static void ProcessEvent(Upnp_EventType EventType, const void *_Event, void *Coo
 		if (Volume != (int) Device->Volume && now > Master->VolumeStampTx + 1000) {
 			Device->Volume = Volume;
 			Master->VolumeStampRx = now;
-			GroupVolume = CalcGroupVolume(Master);
+			GroupVolume = CalcGroupVolume(Master, true);
 			LOG_INFO("[%p]: UPnP Volume local change %d:%d (%s)", Device, (int) Volume, (int) GroupVolume, Device->Master ? "slave": "master");
 			Volume = GroupVolume < 0 ? Volume / Device->Config.MaxVolume : GroupVolume / 100;
 			spotNotify(Device->SpotPlayer, SHADOW_VOLUME, (int) (Volume * UINT16_MAX));

--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -212,6 +212,7 @@ static 	void*	MRThread(void *args);
 static 	void*	UpdateThread(void *args);
 static 	bool 	AddMRDevice(struct sMR *Device, char * UDN, IXML_Document *DescDoc,	const char *location);
 static	bool 	isExcluded(char *Model, char *ModelNumber);
+static	int 	SpotVolume(struct sMR *Device);
 static bool 	Start(bool cold);
 static bool 	Stop(bool exit);
 
@@ -490,6 +491,28 @@ static void ProcessEvent(Upnp_EventType EventType, const void *_Event, void *Coo
 	NFREE(LastChange);
 
 	pthread_mutex_unlock(&Device->Mutex);
+}
+
+/*----------------------------------------------------------------------------*/
+/* A player that has no idea of the renderer's volume announces 0 to Spotify, so
+ * controllers display (and echo back) a null volume until the renderer happens to
+ * signal a local change. Give it the real one, normalized exactly like the UPnP
+ * event feedback does, group volume included, or 0 when we don't know it. Only
+ * cached volumes are used: this runs on the update thread, at times with a device
+ * locked, so it must not go and ask the group members one synchronous request at
+ * a time. A group whose members are still unknown is seeded from its master */
+static int SpotVolume(struct sMR *Device) {
+	int GroupVolume = CalcGroupVolume(Device, false);
+	double Volume;
+
+	if (GroupVolume >= 0) Volume = GroupVolume / 100.0;
+	else if (Device->Volume >= 0 && Device->Config.MaxVolume > 0) Volume = Device->Volume / Device->Config.MaxVolume;
+	else return 0;
+
+	if (Volume > 1) Volume = 1;
+	LOG_INFO("[%p]: initial volume %d:%d", Device, (int) Device->Volume, GroupVolume);
+
+	return (int) (Volume * UINT16_MAX);
 }
 
 /*----------------------------------------------------------------------------*/
@@ -925,8 +948,8 @@ static void *UpdateThread(void *args) {
 							char id[6 * 2 + 1] = { 0 };
 							for (int i = 0; i < 6; i++) sprintf(id + i * 2, "%02x", Device->Config.mac[i]);
 							Device->SpotPlayer = spotCreatePlayer(glClientId, glClientSecret, Device->Config.Name, id, Device->Credentials, glHost, Device->Config.VorbisRate,
-																  Device->Config.Codec, Device->Config.Flow, Device->Config.HTTPContentLength, 
-																  Device->Config.CacheMode, (struct shadowPlayer*) Device, &Device->Mutex);
+																  Device->Config.Codec, Device->Config.Flow, Device->Config.HTTPContentLength,
+																  Device->Config.CacheMode, SpotVolume(Device), (struct shadowPlayer*) Device, &Device->Mutex);
 							pthread_mutex_unlock(&Device->Mutex);
 						} else if (Master && (!Device->Master || Device->Master == Device)) {
 							pthread_mutex_lock(&Device->Mutex);
@@ -984,7 +1007,7 @@ static void *UpdateThread(void *args) {
 					for (int i = 0; i < 6; i++) sprintf(id + i*2, "%02x", Device->Config.mac[i]);
 					Device->SpotPlayer = spotCreatePlayer(glClientId, glClientSecret, Device->Config.Name, id, Device->Credentials, glHost, Device->Config.VorbisRate,
 														  Device->Config.Codec, Device->Config.Flow, Device->Config.HTTPContentLength, 
-														  Device->Config.CacheMode, (struct shadowPlayer*) Device, &Device->Mutex);
+														  Device->Config.CacheMode, SpotVolume(Device), (struct shadowPlayer*) Device, &Device->Mutex);
 					if (!Device->SpotPlayer) {
 						LOG_ERROR("[%p]: cannot create Spotify instance (%s)", Device, Device->Config.Name);
 						pthread_mutex_lock(&Device->Mutex);


### PR DESCRIPTION
Fixes #64.

Connecting a Spotify controller to a spotupnp device sets the volume to 0. Two causes.

**1. spotupnp never asks a renderer its volume.** `CtrlGetVolume()` and
`CtrlGetGroupVolume()` return -1 without sending the action whenever the service has a
control URL, i.e. always for a renderer that implements RenderingControl:

```c
	if (*Service->ControlURL) return Volume;
```

so `Device->Volume` stays -1 after `AddMRDevice()` and `CalcGroupVolume()` can never return
>= 0.

**2. The first frame sent to Spotify carries volume 0.** cspot's `kMessageTypeHello` carries
`device_state.volume`, taken from `ctx->config.volume`, which is 0, and the
`setRemoteVolume()` in `PLAYBACK_START` only corrects it once playback starts. So the
controller is told 0 at the moment of connection.

The two are coupled: with only (1) fixed, `Device->Volume` holds the real volume, the
renderer's initial `LastChange` is then suppressed by the `Volume != (int) Device->Volume`
test, and the player never learns the volume at all.

`AddMRDevice()` therefore passes the volume to the player at creation, before its task
starts, and the player seeds `ctx->config.volume` from it before `SpircHandler` is
constructed, so the very first frame is right. `SpotVolume()` normalizes it the same way the
existing UPnP event feedback does, group volume included, so the seed reports what a local
volume change would report. It reads cached volumes only, as it runs on the update thread
and at times with a device locked. The player's cached volume becomes `std::atomic<int>`,
since the shadow's thread writes it on local changes while the player's task now also reads
it when a session starts.

Fixing (1) also makes the group branch of `SPOT_VOLUME` reachable for the first time, so a
member whose volume cannot be read is now skipped rather than averaged in as -1 and then
scaled from it. **That path would benefit from a check on real Sonos hardware, which I don't
have.** Non-Sonos renderers are unaffected: `CalcGroupVolume()` returns -1 before touching
anything when there is no GroupRenderingControl service.

### Tests

Scripted renderer that advertises RenderingControl, answers `GetVolume` with 42 and never
sends volume events. Before, it logs the subscription and nothing else, no `GetVolume`
request ever arrives. After:

```
spotupnp:  adding renderer (FakeVolRenderer)
spotupnp:  SpotVolume: initial volume 42:-1
renderer:  *** GetVolume asked -> 42
```

Frame level, with temporary instrumentation in `SpircHandler::sendCmd()` and
`handleFrame()`, desktop client connecting to a Hama DIT2010 at volume 62:

```
send type 1  (Hello)  volume 40631 active 0 status 0
recv type 20 (Load)   from <controller>          <- the device being selected
send type 10 (Notify) volume 40631 active 1 status 1
```

40631 is 62% of 65535. In the client the slider now stays where it was, with no dip, and the
session stays connected.

The dip was pinned to the Hello frame with an intermediate build that fixed the guard and
seeded the player's cache but still let cspot send the first frame: there the slider dropped
to 0 on connection and rose to the renderer's volume only when playback started, i.e. the
`PLAYBACK_START` notify carried the right value while the Hello had already announced 0.

Where the reported "always 0" comes from: before these commits the player's cached volume is
only ever filled by a `LastChange` volume event from the renderer, so a renderer that never
sends one leaves it at 0, and 0 is then what both the Hello and the `PLAYBACK_START` notify
announce. A renderer that does send one (my Hama emits it 200ms after the device is added)
fills the cache, so the slider recovers when playback starts and all that remains visible is
the dip on connection. That is probably why this looks intermittent depending on the
renderer.

A renderer that fails `GetVolume` still announces 0. spotraop has the same shape, but RAOP
cannot read a device's volume before the connection is open, so it needs a different answer.
