### PR TITLE
spotupnp: handle NO_MEDIA_PRESENT so a renderer going away doesn't wedge the player

### DIFF
--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -611,6 +611,23 @@ int ActionHandler(Upnp_EventType EventType, const void *Event, void *Cookie) {
 					// move to STOPPED state anyway as next detection will re-sync us
 					p->State = STOPPED;
 					p->ExpectStop = false;
+				} else if (!strcmp(r, "NO_MEDIA_PRESENT") && (p->State == PLAYING || p->State == PAUSED)) {
+					/* the renderer lost its media while we believed it was playing or paused
+					 * (standby, reboot, another controller took it over). It reports this
+					 * instead of STOPPED, so without this branch the device stays PLAYING
+					 * for good: the position poll keeps feeding a bogus 0 to Spotify every
+					 * second and the presence check, which only removes STOPPED devices, never
+					 * kicks in. Treat it as a stop; paused sessions are told as well because,
+					 * unlike a Sonos-style STOPPED-on-pause, the stream really is gone */
+					if (p->ExpectStop) {
+						LOG_INFO("[%p]: uPNP no media present (stop expected)", p);
+					} else {
+						LOG_INFO("[%p]: uPNP no media present, renderer lost its stream", p);
+						if (p->SpotState != SPOT_STOP) spotNotify(p->SpotPlayer, SHADOW_STOP);
+					}
+
+					p->State = STOPPED;
+					p->ExpectStop = false;
 				} else if (!strcmp(r, "PLAYING") && (p->State != PLAYING)) {
 					p->State = PLAYING;
 					LOG_INFO("[%p]: uPNP playing", p);


### PR DESCRIPTION
## Summary

When a renderer loses its media while `spotupnp` believes it is playing (standby, reboot, or another controller taking it over), it answers `GetTransportInfo` with `NO_MEDIA_PRESENT`. The transport-state handler does not recognise that state, so the device is left in `PLAYING` forever: the position poll keeps running and feeds a bogus position of 0 to Spotify on every tick, and the presence check, which only removes `STOPPED` devices, never reclaims it.

## Bug

`ActionHandler()` handles `TRANSITIONING`, `STOPPED`, `PLAYING` and `PAUSED_PLAYBACK`. A renderer that drops its stream reports `NO_MEDIA_PRESENT`, which falls through all of them, so `p->State` stays `PLAYING`. From then on:

- the 1 s position poll keeps calling `GetPositionInfo`, which returns `RelTime` 0, so a position of 0 is pushed to Spotify every ~2.5 s indefinitely (visible as a stream of `adjusting real position 0 from 0` log lines);
- the presence-timeout path in `UpdateThread` only removes a device that is `STOPPED`, so the wedged player is never cleaned up.

Observed with a Frontier Silicon renderer (Hama DIT2010+, an FS2026 chipset) going into standby mid-track: it resets the audio socket, sends SSDP `bye-bye`, then reports `NO_MEDIA_PRESENT` with `RelTime` 0 from that point on, while the bridge sent Spotify a state update every 2.5 s for hours. In one run this produced ~11k position-0 updates in a day for a renderer that was switched off.

## Fix

Treat `NO_MEDIA_PRESENT`, while we believed the renderer was playing or paused, as an unexpected stop:

```c
} else if (!strcmp(r, "NO_MEDIA_PRESENT") && (p->State == PLAYING || p->State == PAUSED)) {
    if (p->ExpectStop) {
        LOG_INFO("[%p]: uPNP no media present (stop expected)", p);
    } else {
        LOG_INFO("[%p]: uPNP no media present, renderer lost its stream", p);
        if (p->SpotState != SPOT_STOP) spotNotify(p->SpotPlayer, SHADOW_STOP);
    }
    p->State = STOPPED;
    p->ExpectStop = false;
}
```

This reuses the existing stop path (the player disconnects from Spotify, freeing the renderer) and moves the device back to `STOPPED`, so polling and presence handling resume their normal course. Paused sessions are notified too, because unlike a Sonos-style `STOPPED`-on-pause the stream really is gone. A stop we caused ourselves is still suppressed via `ExpectStop`.

## Why this is correct

If the renderer reports `NO_MEDIA_PRESENT` there is nothing to play; continuing to treat it as `PLAYING` only produces bogus position updates and a device that can never be reclaimed. Whatever put the renderer into that state, stopping is the right response.

## Testing

Reproduced against the real renderer by forcing it into standby mid-playback: on the current code the bridge kept emitting `adjusting real position 0 from 0` and the device was never removed; with the fix it logs `no media present, renderer lost its stream` within ~1.6 s, disconnects the player, and emits no further position updates.
